### PR TITLE
Alias support

### DIFF
--- a/Design.md
+++ b/Design.md
@@ -5,7 +5,7 @@ One or multiple points of failure with documentation and some logic baked in.
 - Testable (yes, you can test your tests)
 - Maintainable
 - Flexible
-- Unopinionated?
+- Unopinionated -- Is it?
 
 <!-- TODO: Describe test pattern -->
 
@@ -19,17 +19,17 @@ lawbook
     .describe(description: string)
     .define((...input: any) => {
         return true // will call reward
-        return new Promise((resolve) => {resolve(true)}) // will call reward
+        return new Promise((resolve) => {resolve(true)}) // will reward
         // Note that this also means that an async define function will work
 
-        // Every other return (including `undefined`) will call punish. Some examples:
+        // Every other return (including `undefined`) will punish. Some examples:
         return false
         return
         return 'Some message'
 
-        throw new Error() // will call punish
-        throw new AnyTypeOfError() // will call punish
-        expect(true).to.be.false; // will call punish
+        throw new Error() // will punish
+        throw new AnyTypeOfError() // will punish
+        expect(true).to.be.false; // will punish
     })
     .punishment((input: any[], error: Error) => {
         throw new Error() // throw or log error according to config
@@ -55,10 +55,18 @@ lawbook
     .describe(description: string)
     .define((...input: any) => {
     })
-    .on('pass', (input: any[], error: Error) => {
+
+    // Option A
+    .on('fail', (input: any[], error: Error) => {
     })
-    .on('fail', (input: any[]) => {
-    });
+    .on('pass', (input: any[]) => {
+    })
+
+    // Option B
+    .onFail((input: any[], error: Error) => {
+    })
+    .onPass((input: any[]) => {
+    })
 
 lawbook.enforce(namePattern: globString, ...input: any[]);
 ```

--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -67,11 +67,10 @@ export class ConfigManager {
     public parse(config: LawbookConfig) {
         if (Object.keys(config.laws).length === 0) {
             // There is nothing to parse
-            this.log.debug('No unparsed configuration found. Will not parse.');
             return config;
         }
 
-        this.log.debug('Unparsed configuration found. Parsing now...');
+        this.log.debug('Unparsed configuration found. Parsing...');
 
         // Map from `laws` to `_laws`
         Object.entries(config.laws)

--- a/src/errors/LawError.ts
+++ b/src/errors/LawError.ts
@@ -1,5 +1,5 @@
 import * as c from 'ansi-colors';
-import Law from '../law';
+import { Law } from '../law';
 import { severityLevel } from '../config/types';
 
 export class LawError extends Error {
@@ -9,9 +9,9 @@ export class LawError extends Error {
     public law: Law;
 
     /**
-     * String used when logging the error without throwing
+     * Original message. Used when logging error without throwing
      */
-    public warnMessage: string;
+    public _message: string;
 
     /**
      * The severity with which the error was thrown
@@ -19,7 +19,7 @@ export class LawError extends Error {
     public severity: severityLevel;
 
     constructor(law: Law, ...message: string[]) {
-        const warnMessage = message.join(' ');
+        const _message = message.join(' ');
 
         if (law.description) {
             message.push('\n' + c.yellow(law.description));
@@ -30,10 +30,10 @@ export class LawError extends Error {
         this.law = law;
         this.severity = (this.law.config.severity || '').toUpperCase() as severityLevel;
         this.name = `LawError | ${this.severity} ${this.law.name}`;
-        this.warnMessage = warnMessage;
+        this._message = _message;
     }
 
     public toString() {
-        return `${c.grey(this.severity!)} ${this.warnMessage}`;
+        return `${c.grey(this.severity!)} ${this._message}`;
     }
 }

--- a/src/lawbook.ts
+++ b/src/lawbook.ts
@@ -2,7 +2,7 @@ import * as micromatch from 'micromatch';
 import isGlob from 'is-glob';
 
 import { ConfigManager } from './config/manager';
-import Law from './law';
+import { Law } from './law';
 import { logger, Logger } from './log';
 import { LawbookConfig, LawConfig } from './config/types';
 import { LawbookError } from './errors/index';
@@ -11,7 +11,7 @@ import { LawbookError } from './errors/index';
 /**
  * Collection to manage laws
  */
-export default class Lawbook {
+export class Lawbook {
     public config: ConfigManager;
     public laws: Law[];
     private log: Logger;

--- a/src/log.ts
+++ b/src/log.ts
@@ -27,9 +27,11 @@ function fullWidthLine(left: string, right: string) {
 }
 
 function logFormat(info: any) {
-    return fullWidthLine(
-        `${levelMarkers[info.level]()} ${info.message}`,
-        c.grey(`${info.law}`));
+    const logLine = `${levelMarkers[info.level]()} ${info.message}`;
+    if (info.law) {
+        return fullWidthLine(logLine, c.grey(`${info.law}`));
+    }
+    return logLine;
 }
 
 const logger = createLogger({

--- a/test/lawBook.spec.ts
+++ b/test/lawBook.spec.ts
@@ -1,24 +1,24 @@
 import * as sinon from 'sinon';
 import * as _ from 'lodash';
 
-import LawBook from '../src/lawbook';
+import { Lawbook } from '../src/lawbook';
 import { expect } from 'chai';
-import Law from '../src/law';
+import { Law } from '../src/law';
 import { lawbookConfigDefault } from '../src/config/defaults';
 
 
-describe('The class LawBook', function() {
+describe('The class Lawbook', function() {
     it('initializes', function() {
-        const lawBook = new LawBook();
+        const lawBook = new Lawbook();
 
-        expect(lawBook).to.be.instanceOf(LawBook);
+        expect(lawBook).to.be.instanceOf(Lawbook);
         expect(lawBook.laws).to.be.lengthOf(0);
         expect(lawBook.config.full).to.deep.equal(lawbookConfigDefault);
     });
 
     describe('forEach', function() {
         beforeEach(function() {
-            this.lawBook = new LawBook(lawbookConfigDefault);
+            this.lawBook = new Lawbook(lawbookConfigDefault);
 
             this.lawBook.laws = [
                 'foo',
@@ -39,7 +39,7 @@ describe('The class LawBook', function() {
 
     describe('add', function() {
         beforeEach(function() {
-            this.lawBook = new LawBook(lawbookConfigDefault);
+            this.lawBook = new Lawbook(lawbookConfigDefault);
         });
 
         it('creates a new law when called with a string', function() {
@@ -95,7 +95,7 @@ describe('The class LawBook', function() {
 
     describe('omit', function() {
         beforeEach(function() {
-            this.lawBook = new LawBook(lawbookConfigDefault);
+            this.lawBook = new Lawbook(lawbookConfigDefault);
 
             this.lawBook.add('fizz');
             this.lawBook.add('buzz');
@@ -132,7 +132,7 @@ describe('The class LawBook', function() {
 
     describe('has', function() {
         beforeEach(function() {
-            this.lawBook = new LawBook(lawbookConfigDefault);
+            this.lawBook = new Lawbook(lawbookConfigDefault);
 
             this.lawBook.add('fizz');
             this.lawBook.add('buzz');
@@ -158,7 +158,7 @@ describe('The class LawBook', function() {
 
     describe('filter', function() {
         beforeEach(function() {
-            this.lawBook = new LawBook(lawbookConfigDefault);
+            this.lawBook = new Lawbook(lawbookConfigDefault);
 
             this.lawBook.add('fizz');
             this.lawBook.add('buzz');
@@ -195,7 +195,7 @@ describe('The class LawBook', function() {
 
     describe('enforce', function() {
         beforeEach(function() {
-            this.lawBook = new LawBook(lawbookConfigDefault);
+            this.lawBook = new Lawbook(lawbookConfigDefault);
         });
 
         it('logs a warning when there are no laws in the set', async function() {


### PR DESCRIPTION
Adds support for `Law.alias('some/other/law')`